### PR TITLE
fix: warn on malformed ~/.klaatai/config.json

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -106,7 +106,11 @@ export function loadConfig(): Config {
     if (!existsSync(CONFIG_FILE)) return { ...DEFAULT_CONFIG };
     const raw = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
     return { ...DEFAULT_CONFIG, ...raw };
-  } catch {
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `Warning: failed to parse ${CONFIG_FILE} (${detail}); using defaults.\n`,
+    );
     return { ...DEFAULT_CONFIG };
   }
 }


### PR DESCRIPTION
## Summary
- `loadConfig()` still falls back to defaults on parse failure, but now writes a one-line stderr warning with the file path and error.
- Valid configs are unchanged (no extra output).

## Test plan
- [ ] Break `~/.klaatai/config.json` (trailing comma) and run `klaatcode` — see warning
- [ ] Restore valid config — no warning

Fixes #8

Note: issue is currently assigned to @itxhadi27-cmd — happy to close/defer if they already have a PR in progress.