### PR TITLE
feat(whoami): add --json output

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -16,9 +16,19 @@ export function runLogout(): void {
 }
 
 /** Run the `klaatai whoami` command. */
-export async function runWhoami(baseUrl: string): Promise<void> {
+export async function runWhoami(baseUrl: string, json = false): Promise<void> {
   const token = getAuthToken();
   if (!token) {
+    if (json) {
+      console.log(
+        JSON.stringify(
+          { signedIn: false, email: null, plan: null, backend: "unknown" },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
     console.log(chalk.yellow("  Not signed in. Run: klaatai login"));
     return;
   }
@@ -26,6 +36,22 @@ export async function runWhoami(baseUrl: string): Promise<void> {
   try {
     const info = await client.ping();
     const creds = loadCredentials();
+    const backend = info.status === "ok" ? "online" : "offline";
+    if (json) {
+      console.log(
+        JSON.stringify(
+          {
+            signedIn: true,
+            email: creds.email ?? null,
+            plan: creds.plan ?? null,
+            backend,
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
     console.log();
     if (creds.email) console.log(chalk.bold("  Account:  ") + creds.email);
     if (creds.plan)  console.log(chalk.bold("  Plan:     ") + creds.plan);
@@ -33,6 +59,22 @@ export async function runWhoami(baseUrl: string): Promise<void> {
     console.log(chalk.bold("  Backend:  ") + (info.status === "ok" ? chalk.green("Online") : chalk.red("Offline")));
     console.log();
   } catch {
+    if (json) {
+      const creds = loadCredentials();
+      console.log(
+        JSON.stringify(
+          {
+            signedIn: true,
+            email: creds.email ?? null,
+            plan: creds.plan ?? null,
+            backend: "unreachable",
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
     console.error(chalk.red("  Could not reach KlaatAI API."));
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -508,9 +508,10 @@ program
   .command("whoami")
   .description("Show current user info and backend status")
   .option("--base-url <url>", "API base URL override")
-  .action(async (opts: { baseUrl?: string }) => {
+  .option("--json", "Print machine-readable JSON")
+  .action(async (opts: { baseUrl?: string; json?: boolean }) => {
     const config = loadConfig();
-    await runWhoami(opts.baseUrl ?? config.baseUrl);
+    await runWhoami(opts.baseUrl ?? config.baseUrl, Boolean(opts.json));
   });
 
 // ── klaatai serve ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `klaatcode whoami --json` prints `{ signedIn, email, plan, backend }` as pretty JSON.
- Human-readable `whoami` (no flag) is unchanged.
- Fixes #10

## Test plan
- [ ] `klaatcode whoami` still shows the colored account block
- [ ] `klaatcode whoami --json | jq .` yields valid JSON with the documented fields
- [ ] Signed-out `--json` reports `signedIn: false`