### PR TITLE
fix: warn on malformed config.json instead of failing silently (#8)

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -8,6 +8,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+import chalk from "chalk";
 
 const KLAATAI_DIR = join(homedir(), ".klaatai");
 const CREDENTIALS_FILE = join(KLAATAI_DIR, "credentials.json");
@@ -106,7 +107,13 @@ export function loadConfig(): Config {
     if (!existsSync(CONFIG_FILE)) return { ...DEFAULT_CONFIG };
     const raw = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
     return { ...DEFAULT_CONFIG, ...raw };
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      chalk.yellow(
+        `⚠ Failed to parse ${CONFIG_FILE}: ${message}. Falling back to default config.`,
+      ),
+    );
     return { ...DEFAULT_CONFIG };
   }
 }


### PR DESCRIPTION
Closes #8

loadConfig() now prints a yellow warning to stderr (matching the CLI's 
existing chalk.yellow style) naming the config file path and the parse 
error before falling back to defaults, instead of failing silently.

Verified manually:
- Malformed config.json → warning printed, app still starts with defaults
- Valid config.json → no warning, no regression

Note: PR #11 is already open referencing this issue — worth checking 
for overlap before merge.