### PR TITLE
feat(skills): discover Claude Code skills from .claude/skills

### DIFF
--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -63,6 +63,11 @@ export interface Config {
   maxSessionCost?: number;
   /** Per-phase soft token budgets (9.5): "on" (default) or "off". */
   phaseBudgets?: "on" | "off";
+  /** Cross-tool compatibility toggles. */
+  compat?: {
+    /** Discover skills from ~/.claude/skills and .claude/skills (default: true). */
+    importClaudeSkills?: boolean;
+  };
 }
 
 export interface CustomModelConfig {

--- a/src/screens/repl.ts
+++ b/src/screens/repl.ts
@@ -58,6 +58,7 @@ import { dialectForTier, toolsForDialect, dialectIncludesExtras, type ToolDialec
 import { PluginRegistry } from "../tools/plugins.js";
 import { configureDiagnostics } from "../tools/diagnostics.js";
 import { setOutputFilterEnabled } from "../tools/output-filter.js";
+import { expandSkill, formatSkillLocation, loadSkills } from "../skills/loader.js";
 import { PhaseTracker } from "../agent/phase-budget.js";
 import { collectCriticalState, checkSummaryCoverage } from "../agent/collapse-check.js";
 import { killAllBackground } from "../tools/background.js";
@@ -1245,67 +1246,11 @@ export async function runREPL(
     });
   }
 
-  // ─── Skills ───────────────────────────────────────────────────────────────
-  // v2: optional YAML frontmatter between --- fences:
-  //   ---
-  //   name: fix-types        (overrides filename)
-  //   description: Fix all TS type errors
-  //   args: [file or dir]    (usage hint shown in the list)
-  //   ---
-  // Body may reference $ARGUMENTS — replaced with whatever follows the skill
-  // name at invocation (`/skill fix-types src/` or `/fix-types src/`).
-
-  interface Skill {
-    name: string; path: string; content: string; scope: "project" | "global";
-    description?: string; argsHint?: string;
-  }
-
-  function parseSkillFile(raw: string): { meta: Record<string, string>; body: string } {
-    const m = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(raw);
-    if (!m) return { meta: {}, body: raw.trim() };
-    const meta: Record<string, string> = {};
-    for (const line of m[1]!.split("\n")) {
-      const kv = /^([\w-]+):\s*(.*)$/.exec(line.trim());
-      if (kv) meta[kv[1]!.toLowerCase()] = kv[2]!.trim().replace(/^["'\[]|["'\]]$/g, "");
-    }
-    return { meta, body: raw.slice(m[0].length).trim() };
-  }
-
-  function loadSkills(): Skill[] {
-    const skills: Skill[] = [];
-    const dirs: Array<{ dir: string; scope: "project" | "global" }> = [
-      { dir: join(homedir(), ".klaatai", "skills"), scope: "global" },
-      { dir: join(projectRoot, ".klaatai", "skills"),  scope: "project" },
-    ];
-    for (const { dir, scope } of dirs) {
-      if (!existsSync(dir)) continue;
-      try {
-        for (const f of readdirSync(dir)) {
-          if (!f.endsWith(".md")) continue;
-          const p = join(dir, f);
-          try {
-            const { meta, body } = parseSkillFile(readFileSync(p, "utf-8"));
-            skills.push({
-              name: meta["name"] || f.replace(/\.md$/, ""),
-              path: p,
-              content: body,
-              scope,
-              description: meta["description"],
-              argsHint: meta["args"],
-            });
-          } catch { /* skip unreadable */ }
-        }
-      } catch { /* skip unreadable dir */ }
-    }
-    return skills;
-  }
-
-  /** Expand a skill body with invocation arguments ($ARGUMENTS placeholder). */
-  function expandSkill(skill: Skill, args: string): string {
-    if (skill.content.includes("$ARGUMENTS")) {
-      return skill.content.replaceAll("$ARGUMENTS", args || "(none)");
-    }
-    return args ? `${skill.content}\n\nArguments: ${args}` : skill.content;
+  function skillLoadOptions() {
+    return {
+      projectRoot,
+      importClaudeSkills: config.compat?.importClaudeSkills !== false,
+    };
   }
 
   // ─── Hooks ────────────────────────────────────────────────────────────────
@@ -2914,14 +2859,15 @@ export async function runREPL(
         // ── /skill — prompt template skills ───────────────────────────────
         if (slash === "/skill" || slash === "/skills") {
           const arg = parts.slice(1).join(" ").trim();
-          const allSkills = loadSkills();
+          const allSkills = loadSkills(skillLoadOptions());
 
           // /skill list or bare /skill
           if (!arg || arg === "list") {
             if (allSkills.length === 0) {
               pushSystemMsg(
                 "No skills found.\n\n" +
-                "Create a skill: save a `.md` file in `.klaatai/skills/` (project) or `~/.klaatai/skills/` (global).\n\n" +
+                "Create a skill: save a `.md` file in `.klaatai/skills/` (project) or `~/.klaatai/skills/` (global).\n" +
+                "Claude Code skills in `.claude/skills/<name>/SKILL.md` are also discovered when compat is enabled.\n\n" +
                 "Example: `echo '# Fix Types\\nFix all TypeScript type errors in the project.' > .klaatai/skills/fix-types.md`",
               );
             } else {
@@ -2929,7 +2875,7 @@ export async function runREPL(
               for (const s of allSkills) {
                 const desc = s.description ?? s.content.split("\n")[0]!.replace(/^#+\s*/, "").slice(0, 60);
                 const hint = s.argsHint ? ` \`${s.argsHint}\`` : "";
-                lines.push(`  **${s.name}**${hint} *(${s.scope})* — ${desc}`);
+                lines.push(`  **${s.name}**${hint} *(${formatSkillLocation(s)})* — ${desc}`);
               }
               lines.push("\nUsage: `/skill <name> [args]` or directly `/<name> [args]` · `/skill new <name>` to create");
               pushSystemMsg(lines.join("\n"));
@@ -3009,7 +2955,7 @@ export async function runREPL(
         {
           const name = slash.slice(1);
           const rest = parts.slice(1).join(" ").trim();
-          const skill = loadSkills().find(s => s.name === name);
+          const skill = loadSkills(skillLoadOptions()).find(s => s.name === name);
           if (skill) {
             pushSystemMsg(`Invoking skill **${skill.name}**${rest ? ` with \`${rest}\`` : ""}…`);
             void sendMessage(expandSkill(skill, rest));

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expandSkill, formatSkillLocation, loadSkills, parseSkillFile } from "./loader.js";
+
+describe("parseSkillFile", () => {
+  test("parses YAML frontmatter", () => {
+    const raw = `---
+name: demo
+description: Demo skill
+args: [path]
+---
+Body text`;
+    const { meta, body } = parseSkillFile(raw);
+    expect(meta["name"]).toBe("demo");
+    expect(meta["description"]).toBe("Demo skill");
+    expect(meta["args"]).toBe("path");
+    expect(body).toBe("Body text");
+  });
+});
+
+describe("loadSkills", () => {
+  let projectRoot = "";
+  let homeDir = "";
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), "klaat-skills-project-"));
+    homeDir = mkdtempSync(join(tmpdir(), "klaat-skills-home-"));
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  test("discovers Claude project skill from SKILL.md", () => {
+    const skillDir = join(projectRoot, ".claude", "skills", "foo");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---
+name: foo
+description: Claude-format skill
+---
+Do the foo task for $ARGUMENTS`,
+    );
+
+    const skills = loadSkills({ projectRoot, homeDir });
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.name).toBe("foo");
+    expect(skills[0]!.origin).toBe("claude");
+    expect(skills[0]!.sourceLabel).toBe(".claude/skills");
+    expect(formatSkillLocation(skills[0]!)).toBe("project · .claude/skills");
+  });
+
+  test("discovers Claude global skill from ~/.claude/skills", () => {
+    const skillDir = join(homeDir, ".claude", "skills", "bar");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "---\nname: bar\ndescription: global claude skill\n---\nGlobal body",
+    );
+
+    const skills = loadSkills({ projectRoot, homeDir });
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.name).toBe("bar");
+    expect(formatSkillLocation(skills[0]!)).toBe("global · ~/.claude/skills");
+  });
+
+  test("native KlaatCode skill wins on name collision", () => {
+    const claudeDir = join(projectRoot, ".claude", "skills", "shared");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      join(claudeDir, "SKILL.md"),
+      "---\nname: shared\ndescription: imported\n---\nClaude body",
+    );
+
+    const nativeDir = join(projectRoot, ".klaatai", "skills");
+    mkdirSync(nativeDir, { recursive: true });
+    writeFileSync(
+      join(nativeDir, "shared.md"),
+      "---\nname: shared\ndescription: native\n---\nNative body",
+    );
+
+    const skills = loadSkills({ projectRoot, homeDir });
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.origin).toBe("klaatai");
+    expect(skills[0]!.content).toBe("Native body");
+    expect(skills[0]!.sourceLabel).toBe(".klaatai/skills");
+  });
+
+  test("skips Claude roots when importClaudeSkills is false", () => {
+    const skillDir = join(projectRoot, ".claude", "skills", "only-claude");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "---\nname: only-claude\n---\nBody");
+
+    const skills = loadSkills({ projectRoot, homeDir, importClaudeSkills: false });
+    expect(skills).toHaveLength(0);
+  });
+});
+
+describe("expandSkill", () => {
+  test("replaces $ARGUMENTS placeholder", () => {
+    const skill = {
+      name: "x",
+      path: "/tmp/x.md",
+      content: "Fix $ARGUMENTS now",
+      scope: "project" as const,
+      origin: "klaatai" as const,
+      sourceLabel: ".klaatai/skills",
+    };
+    expect(expandSkill(skill, "src/")).toBe("Fix src/ now");
+  });
+});

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,0 +1,140 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export type SkillOrigin = "klaatai" | "claude";
+
+export interface Skill {
+  name: string;
+  path: string;
+  content: string;
+  scope: "project" | "global";
+  origin: SkillOrigin;
+  /** Human-readable source root shown in /skill list. */
+  sourceLabel: string;
+  description?: string;
+  argsHint?: string;
+}
+
+export interface SkillLoadOptions {
+  projectRoot: string;
+  homeDir?: string;
+  /** When false, skip ~/.claude/skills and .claude/skills. Default: true. */
+  importClaudeSkills?: boolean;
+}
+
+export function parseSkillFile(raw: string): { meta: Record<string, string>; body: string } {
+  const m = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(raw);
+  if (!m) return { meta: {}, body: raw.trim() };
+  const meta: Record<string, string> = {};
+  for (const line of m[1]!.split("\n")) {
+    const kv = /^([\w-]+):\s*(.*)$/.exec(line.trim());
+    if (kv) meta[kv[1]!.toLowerCase()] = kv[2]!.trim().replace(/^["'\[]|["'\]]$/g, "");
+  }
+  return { meta, body: raw.slice(m[0].length).trim() };
+}
+
+function skillFromFile(
+  p: string,
+  fallbackName: string,
+  scope: "project" | "global",
+  origin: SkillOrigin,
+  sourceLabel: string,
+): Skill | null {
+  try {
+    const { meta, body } = parseSkillFile(readFileSync(p, "utf-8"));
+    return {
+      name: meta["name"] || fallbackName,
+      path: p,
+      content: body,
+      scope,
+      origin,
+      sourceLabel,
+      description: meta["description"],
+      argsHint: meta["args"],
+    };
+  } catch {
+    return null;
+  }
+}
+
+function loadFlatMdSkills(
+  dir: string,
+  scope: "project" | "global",
+  sourceLabel: string,
+): Skill[] {
+  const skills: Skill[] = [];
+  if (!existsSync(dir)) return skills;
+  try {
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".md")) continue;
+      const skill = skillFromFile(
+        join(dir, f),
+        f.replace(/\.md$/, ""),
+        scope,
+        "klaatai",
+        sourceLabel,
+      );
+      if (skill) skills.push(skill);
+    }
+  } catch { /* skip unreadable dir */ }
+  return skills;
+}
+
+function loadClaudeSkillDir(
+  dir: string,
+  scope: "project" | "global",
+  sourceLabel: string,
+): Skill[] {
+  const skills: Skill[] = [];
+  if (!existsSync(dir)) return skills;
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const skill = skillFromFile(
+        join(dir, entry.name, "SKILL.md"),
+        entry.name,
+        scope,
+        "claude",
+        sourceLabel,
+      );
+      if (skill) skills.push(skill);
+    }
+  } catch { /* skip unreadable dir */ }
+  return skills;
+}
+
+/** Expand a skill body with invocation arguments ($ARGUMENTS placeholder). */
+export function expandSkill(skill: Skill, args: string): string {
+  if (skill.content.includes("$ARGUMENTS")) {
+    return skill.content.replaceAll("$ARGUMENTS", args || "(none)");
+  }
+  return args ? `${skill.content}\n\nArguments: ${args}` : skill.content;
+}
+
+export function formatSkillLocation(skill: Skill): string {
+  return `${skill.scope} · ${skill.sourceLabel}`;
+}
+
+/**
+ * Discover skills from KlaatCode and (optionally) Claude Code directories.
+ * Lower-priority sources are loaded first; native KlaatCode skills win name collisions.
+ */
+export function loadSkills(opts: SkillLoadOptions): Skill[] {
+  const home = opts.homeDir ?? homedir();
+  const importClaude = opts.importClaudeSkills !== false;
+  const byName = new Map<string, Skill>();
+
+  const add = (skills: Skill[]) => {
+    for (const s of skills) byName.set(s.name, s);
+  };
+
+  if (importClaude) {
+    add(loadClaudeSkillDir(join(home, ".claude", "skills"), "global", "~/.claude/skills"));
+    add(loadClaudeSkillDir(join(opts.projectRoot, ".claude", "skills"), "project", ".claude/skills"));
+  }
+  add(loadFlatMdSkills(join(home, ".klaatai", "skills"), "global", "~/.klaatai/skills"));
+  add(loadFlatMdSkills(join(opts.projectRoot, ".klaatai", "skills"), "project", ".klaatai/skills"));
+
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## Summary

Add compatibility discovery for Claude Code skills stored under `~/.claude/skills` and `.claude/skills/<name>/SKILL.md`, gated by `compat.importClaudeSkills` (default on). Native `.klaatai/skills` entries continue to win on name collisions.

## Motivation

Many developers already maintain Claude Code skill libraries. KlaatCode should discover those skills without manual migration so users can invoke them via `/skill` or `/<name>`.

Fixes #38

## Changes

- Extract skill loading into `src/skills/loader.ts` with shared frontmatter parsing
- Discover Claude-format skills from project and user skill directories
- Add `compat.importClaudeSkills` config flag (opt-out)
- Show scope and source directory in `/skill list` (e.g. `project · .claude/skills`)
- Add fixture-based unit tests for discovery, global paths, collision precedence, and opt-out

## Tests

- `bun run typecheck` — pass
- `bun test` — pass (159 tests, including 6 new loader tests)

## Notes

- Skill config is read from the REPL session snapshot at startup (same pattern as other config flags)
- Frontmatter parser matches the existing single-line YAML style used for native skills