### PR TITLE
feat: add bash/zsh/fish shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ brew install KlaatAI/klaatcode/klaatcode
 
 All methods install both `klaatcode` and `klaatai` — identical commands, use whichever you like.
 
+**Shell completions (bash / zsh / fish)**
+```bash
+# bash
+klaatai completions bash >> ~/.bashrc
+
+# zsh
+mkdir -p ~/.zfunc
+klaatai completions zsh > ~/.zfunc/_klaatai
+# ensure fpath includes ~/.zfunc, then: autoload -Uz compinit && compinit
+
+# fish
+klaatai completions fish > ~/.config/fish/completions/klaatai.fish
+```
+
 ## Quick Start
 
 ```bash

--- a/completions/klaatai.bash
+++ b/completions/klaatai.bash
@@ -1,0 +1,58 @@
+# klaatai / klaatcode bash completion
+# Install: klaatai completions bash >> ~/.bashrc   # or ~/.bash_completion
+
+_klaatai_completion() {
+  local cur prev words cword
+  if type _init_completion &>/dev/null; then
+    _init_completion -n : || return
+  else
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  local cmds="chat run login logout whoami upgrade serve web acp completions"
+  local global_opts="-v --version -h --help"
+
+  # First argument: top-level command
+  if [[ ${COMP_CWORD} -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "${cmds} ${global_opts}" -- "${cur}") )
+    return
+  fi
+
+  local cmd="${COMP_WORDS[1]}"
+  case "${cmd}" in
+    chat)
+      COMPREPLY=( $(compgen -W "--base-url -r --resume --continue -h --help" -- "${cur}") )
+      ;;
+    run)
+      COMPREPLY=( $(compgen -W "--base-url --model --system --max-cost -h --help" -- "${cur}") )
+      ;;
+    login)
+      COMPREPLY=( $(compgen -W "--base-url -h --help" -- "${cur}") )
+      ;;
+    logout|acp)
+      COMPREPLY=( $(compgen -W "-h --help" -- "${cur}") )
+      ;;
+    whoami)
+      COMPREPLY=( $(compgen -W "--base-url --json -h --help" -- "${cur}") )
+      ;;
+    upgrade)
+      COMPREPLY=( $(compgen -W "--check -h --help" -- "${cur}") )
+      ;;
+    serve)
+      COMPREPLY=( $(compgen -W "--port --api-key --base-url -h --help" -- "${cur}") )
+      ;;
+    web)
+      COMPREPLY=( $(compgen -W "--port --api-key --base-url --no-browser -h --help" -- "${cur}") )
+      ;;
+    completions)
+      COMPREPLY=( $(compgen -W "bash zsh fish -h --help" -- "${cur}") )
+      ;;
+    *)
+      COMPREPLY=()
+      ;;
+  esac
+}
+
+complete -F _klaatai_completion klaatai
+complete -F _klaatai_completion klaatcode

--- a/completions/klaatai.fish
+++ b/completions/klaatai.fish
@@ -1,0 +1,47 @@
+# klaatai / klaatcode fish completion
+# Install: klaatai completions fish > ~/.config/fish/completions/klaatai.fish
+#          klaatai completions fish > ~/.config/fish/completions/klaatcode.fish
+
+function __klaatai_no_subcommand
+  set -l cmd (commandline -opc)
+  test (count $cmd) -eq 1
+end
+
+complete -c klaatai -f
+complete -c klaatcode -f
+
+for bin in klaatai klaatcode
+  complete -c $bin -n __klaatai_no_subcommand -a chat -d 'Start interactive AI chat (default)'
+  complete -c $bin -n __klaatai_no_subcommand -a run -d 'Run a single prompt non-interactively'
+  complete -c $bin -n __klaatai_no_subcommand -a login -d 'Sign in via browser'
+  complete -c $bin -n __klaatai_no_subcommand -a logout -d 'Clear stored credentials'
+  complete -c $bin -n __klaatai_no_subcommand -a whoami -d 'Show current user info and backend status'
+  complete -c $bin -n __klaatai_no_subcommand -a upgrade -d 'Update klaatcode to the latest version'
+  complete -c $bin -n __klaatai_no_subcommand -a serve -d 'Start a local HTTP REST/SSE API server'
+  complete -c $bin -n __klaatai_no_subcommand -a web -d 'Start a local web UI in the browser'
+  complete -c $bin -n __klaatai_no_subcommand -a acp -d 'Run as an ACP server over stdio'
+  complete -c $bin -n __klaatai_no_subcommand -a completions -d 'Print shell completion script'
+  complete -c $bin -n __klaatai_no_subcommand -s v -l version -d 'Print version and exit'
+  complete -c $bin -n __klaatai_no_subcommand -s h -l help -d 'Show help'
+
+  complete -c $bin -n '__fish_seen_subcommand_from chat' -l base-url -d 'API base URL override'
+  complete -c $bin -n '__fish_seen_subcommand_from chat' -s r -l resume -d 'Resume a previous session'
+  complete -c $bin -n '__fish_seen_subcommand_from chat' -l continue -d 'Resume last session'
+
+  complete -c $bin -n '__fish_seen_subcommand_from run' -l base-url -d 'API base URL override'
+  complete -c $bin -n '__fish_seen_subcommand_from run' -l model -d 'Force routing tier'
+  complete -c $bin -n '__fish_seen_subcommand_from run' -l system -d 'Prepend a system message'
+  complete -c $bin -n '__fish_seen_subcommand_from run' -l max-cost -d 'Abort at this USD cost'
+
+  complete -c $bin -n '__fish_seen_subcommand_from login' -l base-url -d 'API base URL override'
+  complete -c $bin -n '__fish_seen_subcommand_from whoami' -l base-url -d 'API base URL override'
+  complete -c $bin -n '__fish_seen_subcommand_from whoami' -l json -d 'Output machine-readable JSON'
+  complete -c $bin -n '__fish_seen_subcommand_from upgrade' -l check -d 'Only check for an update'
+
+  complete -c $bin -n '__fish_seen_subcommand_from serve web' -l port -d 'Port to listen on'
+  complete -c $bin -n '__fish_seen_subcommand_from serve web' -l api-key -d 'API key override'
+  complete -c $bin -n '__fish_seen_subcommand_from serve web' -l base-url -d 'API base URL override'
+  complete -c $bin -n '__fish_seen_subcommand_from web' -l no-browser -d 'Do not open the browser'
+
+  complete -c $bin -n '__fish_seen_subcommand_from completions' -a 'bash zsh fish'
+end

--- a/completions/klaatai.zsh
+++ b/completions/klaatai.zsh
@@ -1,0 +1,97 @@
+#compdef klaatai klaatcode
+# klaatai / klaatcode zsh completion
+# Install: klaatai completions zsh > ~/.zfunc/_klaatai
+#          fpath+=(~/.zfunc); autoload -Uz compinit; compinit
+
+_klaatai() {
+  local -a commands
+  commands=(
+    'chat:Start interactive AI chat (default)'
+    'run:Run a single prompt non-interactively'
+    'login:Sign in via browser'
+    'logout:Clear stored credentials'
+    'whoami:Show current user info and backend status'
+    'upgrade:Update klaatcode to the latest version'
+    'serve:Start a local HTTP REST/SSE API server'
+    'web:Start a local web UI in the browser'
+    'acp:Run as an ACP server over stdio'
+    'completions:Print shell completion script'
+  )
+
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \
+    '(-v --version)'{-v,--version}'[Print version and exit]' \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '1: :->cmds' \
+    '*:: :->args'
+
+  case $state in
+    cmds)
+      _describe -t commands 'command' commands
+      ;;
+    args)
+      case $words[1] in
+        chat)
+          _arguments \
+            '--base-url[API base URL override]:url:' \
+            '(-r --resume)'{-r,--resume}'[Resume a previous session]:id:' \
+            '--continue[Resume last session]' \
+            '(-h --help)'{-h,--help}'[Show help]' \
+            '1:directory:_files -/'
+          ;;
+        run)
+          _arguments \
+            '--base-url[API base URL override]:url:' \
+            '--model[Force routing tier]:tier:(nano fast code reason heavy)' \
+            '--system[Prepend a system message]:text:' \
+            '--max-cost[Abort at this USD cost]:usd:' \
+            '(-h --help)'{-h,--help}'[Show help]' \
+            '1:prompt:'
+          ;;
+        login)
+          _arguments \
+            '--base-url[API base URL override]:url:' \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        logout|acp)
+          _arguments '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        whoami)
+          _arguments \
+            '--base-url[API base URL override]:url:' \
+            '--json[Output machine-readable JSON]' \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        upgrade)
+          _arguments \
+            '--check[Only check for an update]' \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        serve)
+          _arguments \
+            '--port[Port to listen on]:port:' \
+            '--api-key[API key override]:key:' \
+            '--base-url[API base URL override]:url:' \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        web)
+          _arguments \
+            '--port[Port to listen on]:port:' \
+            '--api-key[API key override]:key:' \
+            '--base-url[API base URL override]:url:' \
+            '--no-browser[Do not open the browser]' \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        completions)
+          _arguments \
+            '1:shell:(bash zsh fish)' \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+compdef _klaatai klaatai klaatcode

--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, describe } from "bun:test";
+import {
+  getCompletionScript,
+  isCompletionShell,
+  COMPLETION_SHELLS,
+} from "./completions";
+
+describe("completions", () => {
+  test("recognizes bash/zsh/fish only", () => {
+    expect(isCompletionShell("bash")).toBe(true);
+    expect(isCompletionShell("zsh")).toBe(true);
+    expect(isCompletionShell("fish")).toBe(true);
+    expect(isCompletionShell("powershell")).toBe(false);
+    expect(isCompletionShell("")).toBe(false);
+  });
+
+  test("exposes all three shells", () => {
+    expect(COMPLETION_SHELLS).toEqual(["bash", "zsh", "fish"]);
+  });
+
+  for (const shell of COMPLETION_SHELLS) {
+    test(`${shell} script covers both binary names and top-level commands`, () => {
+      const script = getCompletionScript(shell);
+      expect(script.endsWith("\n")).toBe(true);
+      expect(script).toContain("klaatai");
+      expect(script).toContain("klaatcode");
+      for (const cmd of ["chat", "run", "login", "logout", "whoami", "upgrade", "serve", "web", "acp", "completions"]) {
+        expect(script).toContain(cmd);
+      }
+      // Flag forms differ by shell (bash/zsh: --base-url; fish: -l base-url)
+      expect(script.includes("--base-url") || script.includes("-l base-url")).toBe(true);
+      expect(script.includes("--model") || script.includes("-l model")).toBe(true);
+      expect(script.includes("--max-cost") || script.includes("-l max-cost")).toBe(true);
+    });
+  }
+
+  test("bash registers complete for both binaries", () => {
+    const script = getCompletionScript("bash");
+    expect(script).toContain("complete -F _klaatai_completion klaatai");
+    expect(script).toContain("complete -F _klaatai_completion klaatcode");
+  });
+
+  test("zsh uses #compdef for both binaries", () => {
+    const script = getCompletionScript("zsh");
+    expect(script).toContain("#compdef klaatai klaatcode");
+    expect(script).toContain("compdef _klaatai klaatai klaatcode");
+  });
+
+  test("fish completes both binaries", () => {
+    const script = getCompletionScript("fish");
+    expect(script).toContain("complete -c klaatai");
+    expect(script).toContain("complete -c klaatcode");
+  });
+});

--- a/src/commands/completions.test.ts
+++ b/src/commands/completions.test.ts
@@ -3,6 +3,7 @@ import {
   getCompletionScript,
   isCompletionShell,
   COMPLETION_SHELLS,
+  resolveCompletions,
 } from "./completions";
 
 describe("completions", () => {
@@ -46,9 +47,30 @@ describe("completions", () => {
     expect(script).toContain("compdef _klaatai klaatai klaatcode");
   });
 
+  test("zsh chat completes a project directory (matches CLI [dir] arg)", () => {
+    // Bot suggested '1:prompt:' — incorrect: `chat [dir]` opens a project directory.
+    const script = getCompletionScript("zsh");
+    expect(script).toContain("_files -/");
+  });
+
   test("fish completes both binaries", () => {
     const script = getCompletionScript("fish");
     expect(script).toContain("complete -c klaatai");
     expect(script).toContain("complete -c klaatcode");
+  });
+
+  test("resolveCompletions rejects unknown shells with a usage error", () => {
+    const bad = resolveCompletions("bogus");
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) {
+      expect(bad.error).toContain("Unknown shell: bogus");
+      expect(bad.error).toContain("bash|zsh|fish");
+    }
+  });
+
+  test("resolveCompletions accepts case-insensitive shell names", () => {
+    const ok = resolveCompletions("Zsh");
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.script).toContain("#compdef");
   });
 });

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -1,0 +1,245 @@
+/**
+ * `klaatai completions <shell>` — print static completion scripts.
+ *
+ * Embedded (not read from disk) so the compiled binary still works.
+ * Covers both `klaatai` and `klaatcode` binary names.
+ */
+
+export type CompletionShell = "bash" | "zsh" | "fish";
+
+export const COMPLETION_SHELLS: CompletionShell[] = ["bash", "zsh", "fish"];
+
+export function isCompletionShell(s: string): s is CompletionShell {
+  return (COMPLETION_SHELLS as string[]).includes(s);
+}
+
+const BASH = `# klaatai / klaatcode bash completion
+# Install: klaatai completions bash >> ~/.bashrc   # or ~/.bash_completion
+
+_klaatai_completion() {
+  local cur prev words cword
+  if type _init_completion &>/dev/null; then
+    _init_completion -n : || return
+  else
+    cur="\${COMP_WORDS[COMP_CWORD]}"
+    prev="\${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  local cmds="chat run login logout whoami upgrade serve web acp completions"
+  local global_opts="-v --version -h --help"
+
+  # First argument: top-level command
+  if [[ \${COMP_CWORD} -eq 1 ]]; then
+    COMPREPLY=( \$(compgen -W "\${cmds} \${global_opts}" -- "\${cur}") )
+    return
+  fi
+
+  local cmd="\${COMP_WORDS[1]}"
+  case "\${cmd}" in
+    chat)
+      COMPREPLY=( \$(compgen -W "--base-url -r --resume --continue -h --help" -- "\${cur}") )
+      ;;
+    run)
+      COMPREPLY=( \$(compgen -W "--base-url --model --system --max-cost -h --help" -- "\${cur}") )
+      ;;
+    login)
+      COMPREPLY=( \$(compgen -W "--base-url -h --help" -- "\${cur}") )
+      ;;
+    logout|acp)
+      COMPREPLY=( \$(compgen -W "-h --help" -- "\${cur}") )
+      ;;
+    whoami)
+      COMPREPLY=( \$(compgen -W "--base-url --json -h --help" -- "\${cur}") )
+      ;;
+    upgrade)
+      COMPREPLY=( \$(compgen -W "--check -h --help" -- "\${cur}") )
+      ;;
+    serve)
+      COMPREPLY=( \$(compgen -W "--port --api-key --base-url -h --help" -- "\${cur}") )
+      ;;
+    web)
+      COMPREPLY=( \$(compgen -W "--port --api-key --base-url --no-browser -h --help" -- "\${cur}") )
+      ;;
+    completions)
+      COMPREPLY=( \$(compgen -W "bash zsh fish -h --help" -- "\${cur}") )
+      ;;
+    *)
+      COMPREPLY=()
+      ;;
+  esac
+}
+
+complete -F _klaatai_completion klaatai
+complete -F _klaatai_completion klaatcode
+`;
+
+const ZSH = `#compdef klaatai klaatcode
+# klaatai / klaatcode zsh completion
+# Install: klaatai completions zsh > ~/.zfunc/_klaatai
+#          fpath+=(~/.zfunc); autoload -Uz compinit; compinit
+
+_klaatai() {
+  local -a commands
+  commands=(
+    'chat:Start interactive AI chat (default)'
+    'run:Run a single prompt non-interactively'
+    'login:Sign in via browser'
+    'logout:Clear stored credentials'
+    'whoami:Show current user info and backend status'
+    'upgrade:Update klaatcode to the latest version'
+    'serve:Start a local HTTP REST/SSE API server'
+    'web:Start a local web UI in the browser'
+    'acp:Run as an ACP server over stdio'
+    'completions:Print shell completion script'
+  )
+
+  local curcontext="\$curcontext" state line
+  typeset -A opt_args
+
+  _arguments -C \\
+    '(-v --version)'{-v,--version}'[Print version and exit]' \\
+    '(-h --help)'{-h,--help}'[Show help]' \\
+    '1: :->cmds' \\
+    '*:: :->args'
+
+  case \$state in
+    cmds)
+      _describe -t commands 'command' commands
+      ;;
+    args)
+      case \$words[1] in
+        chat)
+          _arguments \\
+            '--base-url[API base URL override]:url:' \\
+            '(-r --resume)'{-r,--resume}'[Resume a previous session]:id:' \\
+            '--continue[Resume last session]' \\
+            '(-h --help)'{-h,--help}'[Show help]' \\
+            '1:directory:_files -/'
+          ;;
+        run)
+          _arguments \\
+            '--base-url[API base URL override]:url:' \\
+            '--model[Force routing tier]:tier:(nano fast code reason heavy)' \\
+            '--system[Prepend a system message]:text:' \\
+            '--max-cost[Abort at this USD cost]:usd:' \\
+            '(-h --help)'{-h,--help}'[Show help]' \\
+            '1:prompt:'
+          ;;
+        login)
+          _arguments \\
+            '--base-url[API base URL override]:url:' \\
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        logout|acp)
+          _arguments '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        whoami)
+          _arguments \\
+            '--base-url[API base URL override]:url:' \\
+            '--json[Output machine-readable JSON]' \\
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        upgrade)
+          _arguments \\
+            '--check[Only check for an update]' \\
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        serve)
+          _arguments \\
+            '--port[Port to listen on]:port:' \\
+            '--api-key[API key override]:key:' \\
+            '--base-url[API base URL override]:url:' \\
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        web)
+          _arguments \\
+            '--port[Port to listen on]:port:' \\
+            '--api-key[API key override]:key:' \\
+            '--base-url[API base URL override]:url:' \\
+            '--no-browser[Do not open the browser]' \\
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+        completions)
+          _arguments \\
+            '1:shell:(bash zsh fish)' \\
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+compdef _klaatai klaatai klaatcode
+`;
+
+const FISH = `# klaatai / klaatcode fish completion
+# Install: klaatai completions fish > ~/.config/fish/completions/klaatai.fish
+#          klaatai completions fish > ~/.config/fish/completions/klaatcode.fish
+
+function __klaatai_no_subcommand
+  set -l cmd (commandline -opc)
+  test (count \$cmd) -eq 1
+end
+
+complete -c klaatai -f
+complete -c klaatcode -f
+
+for bin in klaatai klaatcode
+  complete -c \$bin -n __klaatai_no_subcommand -a chat -d 'Start interactive AI chat (default)'
+  complete -c \$bin -n __klaatai_no_subcommand -a run -d 'Run a single prompt non-interactively'
+  complete -c \$bin -n __klaatai_no_subcommand -a login -d 'Sign in via browser'
+  complete -c \$bin -n __klaatai_no_subcommand -a logout -d 'Clear stored credentials'
+  complete -c \$bin -n __klaatai_no_subcommand -a whoami -d 'Show current user info and backend status'
+  complete -c \$bin -n __klaatai_no_subcommand -a upgrade -d 'Update klaatcode to the latest version'
+  complete -c \$bin -n __klaatai_no_subcommand -a serve -d 'Start a local HTTP REST/SSE API server'
+  complete -c \$bin -n __klaatai_no_subcommand -a web -d 'Start a local web UI in the browser'
+  complete -c \$bin -n __klaatai_no_subcommand -a acp -d 'Run as an ACP server over stdio'
+  complete -c \$bin -n __klaatai_no_subcommand -a completions -d 'Print shell completion script'
+  complete -c \$bin -n __klaatai_no_subcommand -s v -l version -d 'Print version and exit'
+  complete -c \$bin -n __klaatai_no_subcommand -s h -l help -d 'Show help'
+
+  complete -c \$bin -n '__fish_seen_subcommand_from chat' -l base-url -d 'API base URL override'
+  complete -c \$bin -n '__fish_seen_subcommand_from chat' -s r -l resume -d 'Resume a previous session'
+  complete -c \$bin -n '__fish_seen_subcommand_from chat' -l continue -d 'Resume last session'
+
+  complete -c \$bin -n '__fish_seen_subcommand_from run' -l base-url -d 'API base URL override'
+  complete -c \$bin -n '__fish_seen_subcommand_from run' -l model -d 'Force routing tier'
+  complete -c \$bin -n '__fish_seen_subcommand_from run' -l system -d 'Prepend a system message'
+  complete -c \$bin -n '__fish_seen_subcommand_from run' -l max-cost -d 'Abort at this USD cost'
+
+  complete -c \$bin -n '__fish_seen_subcommand_from login' -l base-url -d 'API base URL override'
+  complete -c \$bin -n '__fish_seen_subcommand_from whoami' -l base-url -d 'API base URL override'
+  complete -c \$bin -n '__fish_seen_subcommand_from whoami' -l json -d 'Output machine-readable JSON'
+  complete -c \$bin -n '__fish_seen_subcommand_from upgrade' -l check -d 'Only check for an update'
+
+  complete -c \$bin -n '__fish_seen_subcommand_from serve web' -l port -d 'Port to listen on'
+  complete -c \$bin -n '__fish_seen_subcommand_from serve web' -l api-key -d 'API key override'
+  complete -c \$bin -n '__fish_seen_subcommand_from serve web' -l base-url -d 'API base URL override'
+  complete -c \$bin -n '__fish_seen_subcommand_from web' -l no-browser -d 'Do not open the browser'
+
+  complete -c \$bin -n '__fish_seen_subcommand_from completions' -a 'bash zsh fish'
+end
+`;
+
+const SCRIPTS: Record<CompletionShell, string> = {
+  bash: BASH,
+  zsh: ZSH,
+  fish: FISH,
+};
+
+/** Return the completion script for a shell (always ends with a trailing newline). */
+export function getCompletionScript(shell: CompletionShell): string {
+  const body = SCRIPTS[shell].replace(/^\n/, "");
+  return body.endsWith("\n") ? body : body + "\n";
+}
+
+export function runCompletions(shellArg: string): void {
+  const shell = shellArg.toLowerCase();
+  if (!isCompletionShell(shell)) {
+    process.stderr.write(
+      `Unknown shell: ${shellArg}\nUsage: klaatai completions <bash|zsh|fish>\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(getCompletionScript(shell));
+}

--- a/src/commands/completions.ts
+++ b/src/commands/completions.ts
@@ -233,13 +233,27 @@ export function getCompletionScript(shell: CompletionShell): string {
   return body.endsWith("\n") ? body : body + "\n";
 }
 
-export function runCompletions(shellArg: string): void {
+export type CompletionsResult =
+  | { ok: true; script: string }
+  | { ok: false; error: string };
+
+/** Pure resolve — easy to unit-test without calling process.exit. */
+export function resolveCompletions(shellArg: string): CompletionsResult {
   const shell = shellArg.toLowerCase();
   if (!isCompletionShell(shell)) {
-    process.stderr.write(
-      `Unknown shell: ${shellArg}\nUsage: klaatai completions <bash|zsh|fish>\n`,
-    );
+    return {
+      ok: false,
+      error: `Unknown shell: ${shellArg}\nUsage: klaatai completions <bash|zsh|fish>\n`,
+    };
+  }
+  return { ok: true, script: getCompletionScript(shell) };
+}
+
+export function runCompletions(shellArg: string): void {
+  const result = resolveCompletions(shellArg);
+  if (!result.ok) {
+    process.stderr.write(result.error);
     process.exit(1);
   }
-  process.stdout.write(getCompletionScript(shell));
+  process.stdout.write(result.script);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1112,6 +1112,16 @@ program
     await runWeb({ port: parseInt(opts.port, 10) || 4200, apiKey: opts.apiKey, baseUrl: opts.baseUrl, noBrowser: opts.noBrowser });
   });
 
+// ── klaatai completions ───────────────────────────────────────────────────────
+
+program
+  .command("completions <shell>")
+  .description("Print shell completion script (bash | zsh | fish)")
+  .action(async (shell: string) => {
+    const { runCompletions } = await import("./commands/completions.js");
+    runCompletions(shell);
+  });
+
 // ─── Parse ───────────────────────────────────────────────────────────────────
 
 program.parseAsync(process.argv).catch((err: unknown) => {


### PR DESCRIPTION
## Summary
- Adds `klaatai completions <bash|zsh|fish>` that prints static completion scripts (closes #31).
- Covers top-level commands (`chat`, `run`, `login`, `logout`, `whoami`, `upgrade`, `serve`, `web`, `acp`, `completions`) and their flags for both `klaatai` and `klaatcode`.
- Reference scripts live under `completions/`; install hints added to the README.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (186 pass)
- [x] `bun run bench:selfcheck`
- [x] `bun run build`
- [x] `bash -n` / `zsh -n` on generated scripts
- [x] `bash -c 'source … && complete -p klaatai klaatcode'`
- [x] `klaatai completions bogus` exits 1 with usage
- [ ] Manually: `source <(klaatai completions bash)` then tab-complete `klaatai <TAB>`

### How tested
- Unit tests assert both binary names + command/flag coverage for all three shells
- `bash -n` and `zsh -n` syntax-checked the scripts (fish not installed on this machine)