### PR TITLE
feat: add Slack built-in MCP preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Three-layer model — safe read-only tools run silently; everything else asks:
 
 Full MCP client, both transports:
 
-- **stdio** — local servers, configured in `.klaatai/mcp.json`, built-in presets (filesystem, GitHub, Postgres, Puppeteer, Brave Search, Fetch, …)
+- **stdio** — local servers, configured in `.klaatai/mcp.json`, built-in presets (filesystem, GitHub, Postgres, Puppeteer, Brave Search, SQLite, Slack, …)
 - **Streamable HTTP** — remote servers via `"url"` config or `/mcp add <url>`; SSE and JSON responses, session management, and **OAuth 2.1** (discovery + dynamic client registration + PKCE browser flow) when the server requires auth — tokens cached in `~/.klaatai/mcp-oauth.json`
 
 Manage live with `/mcp`.

--- a/src/mcp/presets.test.ts
+++ b/src/mcp/presets.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { MCP_PRESETS, getMCPPreset } from "./presets";
+
+describe("MCP presets", () => {
+  test("slack preset is registered", () => {
+    const slack = getMCPPreset("slack");
+    expect(slack).toBeDefined();
+    expect(slack!.name).toBe("Slack");
+    expect(slack!.envVars).toContain("SLACK_BOT_TOKEN");
+    expect(slack!.envVars).toContain("SLACK_TEAM_ID");
+    expect(slack!.config.command).toBe("npx");
+    expect(slack!.config.args).toEqual(["-y", "@modelcontextprotocol/server-slack"]);
+  });
+
+  test("preset lookup is case-insensitive", () => {
+    expect(getMCPPreset("Slack")?.id).toBe("slack");
+  });
+
+  test("ids are unique", () => {
+    const ids = MCP_PRESETS.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/src/mcp/presets.ts
+++ b/src/mcp/presets.ts
@@ -100,6 +100,17 @@ export const MCP_PRESETS: MCPPreset[] = [
       description: "SQLite access via MCP",
     },
   },
+  {
+    id:          "slack",
+    name:        "Slack",
+    description: "Read channels, post messages, and search Slack history",
+    envVars:     ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"],
+    config: {
+      command:     "npx",
+      args:        ["-y", "@modelcontextprotocol/server-slack"],
+      description: "Slack API via MCP — requires SLACK_BOT_TOKEN and SLACK_TEAM_ID env vars",
+    },
+  },
 ];
 
 /** Look up a preset by id (case-insensitive). */


### PR DESCRIPTION
## Summary
- Adds a **Slack** built-in MCP preset to `src/mcp/presets.ts` (closes #3 for Slack).
- Uses `npx -y @modelcontextprotocol/server-slack` with `SLACK_BOT_TOKEN` + `SLACK_TEAM_ID`.
- README MCP preset list updated; unit test covers registration.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run build`
- [x] With valid Slack env vars: `/mcp enable slack` and confirm tools connect