### PR TITLE
Fix broken star history chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,11 +554,11 @@ Found a vulnerability? Please don't open a public issue — see [SECURITY.md](SE
 
 ## Star History
 
-<a href="https://star-history.com/#KlaatAI/klaatcode&Date">
+<a href="https://star-history.dera.page/#KlaatAI/klaatcode&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=KlaatAI/klaatcode&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=KlaatAI/klaatcode&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=KlaatAI/klaatcode&type=Date" width="600" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=KlaatAI/klaatcode&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=KlaatAI/klaatcode&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=KlaatAI/klaatcode&type=Date" width="600" />
  </picture>
 </a>
 


### PR DESCRIPTION
The README's star history chart is currently broken, so it no longer displays the project's growth. Update its links to restore the chart while keeping the repository reference current.